### PR TITLE
add: pagenation for naillogs

### DIFF
--- a/app/controllers/naillogs_controller.rb
+++ b/app/controllers/naillogs_controller.rb
@@ -4,7 +4,7 @@ class NaillogsController < ApplicationController
   before_action :load_nail_items, only: %i[new create edit update]
 
   def index
-    @naillogs = Naillog.published.order(created_at: :desc)
+    @naillogs = Naillog.published.order(created_at: :desc).page(params[:page]).per(5).includes(:user)
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,1 @@
+<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "bg-white hover:bg-secondary text-gray-800 font-light py-1 px-2 border border-primary rounded shadow" %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,1 @@
+<span class="tracking-widest text-gray-600 px-2"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,1 @@
+<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "bg-white hover:bg-secondary text-gray-800 font-light py-1 px-2 border border-primary rounded shadow" %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/app/views/naillogs/index.html.erb
+++ b/app/views/naillogs/index.html.erb
@@ -6,4 +6,9 @@
             <%= render partial: "log", collection: @naillogs %>
           </ul>
     </div>
+
+    <!-- Pagination -->
+    <div class="text-center flex self-center join justify-center">
+      <%= paginate @naillogs %>
+    </div>
 </div>

--- a/app/views/pages/_naillog.html.erb
+++ b/app/views/pages/_naillog.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="text-center mt-3 leading-loose">
     <button class="btn btn-primary mb-3 text-xs">
-      <%= link_to "Nail Logを投稿する", root_path %>
+      <%= link_to "Nail Logを投稿する", new_naillog_path %>
     </button>
   </div>
 

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,3 +37,10 @@ ja:
               required: "を選択するか、不要な行を削除してください"
   defaults:
     delete_confirm: "削除してよろしいですか？"
+  views:
+    pagination:
+    first: "&laquo;"
+    last: "&raquo;"
+    previous: "&lsaquo;"
+    next: "&rsaquo;"
+    truncate: "&hellip;"

--- a/db/seeds/production/colors.rb
+++ b/db/seeds/production/colors.rb
@@ -1,4 +1,3 @@
-
 # 色データ生成
 p "create Colors"
 Color.find_or_create_by!(


### PR DESCRIPTION
### 目的
nail logの一覧ページ表示時にページネーションが表示されるようにする

### 内容
- gem kaminariの導入
- ルーティングの設定
- 一覧ページの作成(naillogs/index.html.erb)


### 関連ファイル
- gemfile
  - gem 'kaminari', '1.2.2'
  - gem 'bootstrap5-kaminari-views'
- controller
  -  naillogs
- views
  - naillogs/index

### 完了目安
- naillogs/indexで5件ずつ表示される
- 〃でページネーションが表示される
