### PR TITLE
add:config/initializers/carrierwave.rb

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,3 @@
+CarrierWave.configure do |config|
+  config.cache_dir = '/tmp/uploads'
+end


### PR DESCRIPTION
## 概要
本番環境にて以下エラーが発生していたため、config/initializers/carrierwave.rbを生成、必要事項の記述を行った。
`[33b9e219-690d-4717-a8c5-2c5e0bdfd144] Errno::EACCES (Permission denied @ dir_s_mkdir - /rails/public/uploads/tmp/1767674606-76817221826827-0002-9247):`